### PR TITLE
Fix version conflict regarding fog

### DIFF
--- a/vagrant-openstack.gemspec
+++ b/vagrant-openstack.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |gem|
   gem.summary       = "Enables Vagrant to manage machines in OpenStack Cloud."
   gem.homepage      = "http://www.vagrantup.com"
 
-  gem.add_runtime_dependency "fog", "~> 1.15.0"
+  gem.add_runtime_dependency "fog", "~> 1.22"
 
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec", "~> 2.13.0"
+  gem.add_development_dependency "rake", "~> 0"
+  gem.add_development_dependency "rspec", "~> 2.13"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hello Mathieu, 

please update the file ```vagrant-openstack.gemspec``` to fix the following version conflicts / warnings during the build and installation of the ```vagrant-openstack``` plugin. 

```ruby
dhoppe@macbook /tmp/vagrant-openstack (git)-[master] % gem build vagrant-openstack.gemspec
WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
http://opensource.org/licenses/alphabetical
WARNING:  description and summary are identical
WARNING:  pessimistic dependency on fog (~> 1.22.0) may be overly strict
  if fog is semantically versioned, use:
    add_runtime_dependency 'fog', '~> 1.22', '>= 1.22.0'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  pessimistic dependency on rspec (~> 2.13.0, development) may be overly strict
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 2.13', '>= 2.13.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: vagrant-openstack
  Version: 1.0.0
  File: vagrant-openstack-1.0.0.gem
```

```ruby
dhoppe@macbook /tmp/vagrant-openstack (git)-[master] % vagrant plugin install vagrant-openstack-1.0.0.gem
Installing the 'vagrant-openstack-1.0.0.gem' plugin. This can take a few minutes...
The plugin(s) can't be installed due to the version conflicts below.
This means that the plugins depend on a library version that conflicts
with other plugins or Vagrant itself, creating an impossible situation
where Vagrant wouldn't be able to load the plugins.

You can fix the issue by either removing a conflicting plugin or
by contacting a plugin author to see if they can address the conflict.

Vagrant could not find compatible versions for gem "fog":
  In Gemfile:
    vagrant-aws (>= 0) ruby depends on
      fog (~> 1.22) ruby

    vagrant-openstack (= 1.0.0) ruby depends on
      fog (~> 1.15.0) ruby

vagrant plugin install vagrant-openstack-1.0.0.gem  5.20s user 0.73s system 43% cpu 13.517 total
```

Kind regards, 
Dennis